### PR TITLE
Closes issue #40.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The `status` configuration value is an object consisting of the following proper
 | actions | An array of buttons to be displayed on the app dashboard. |
 | approval | An array of user type values that can approve the item. |
 | checklists | Displayed on the approval/submission form. |
+| createTestSite | If set to true, will create the test site for the application. |
 | notification | The email information to notify users on submission/approval of the item. |
 
 #### Actions

--- a/assets/config.json
+++ b/assets/config.json
@@ -80,6 +80,7 @@
             ]
         },
         "Pending Approval": {
+            "createTestSite": true,
             "actions": [
                 "View",
                 "ApproveReject"

--- a/src/appCfg.ts
+++ b/src/appCfg.ts
@@ -30,6 +30,7 @@ export interface IStatus {
     actions?: string[];
     approval?: string[];
     checklists?: string[];
+    createTestSite?: boolean;
     lastStep: boolean;
     name: string;
     notification?: IEmail[];

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -59,8 +59,35 @@ export class AppForms {
 
                                         // Send the notification
                                         AppNotifications.sendEmail(status.nextStep, item).then(() => {
-                                            // Call the update event
-                                            onUpdate();
+                                            // See if the test app catalog exists and we are creating the test site
+                                            if (DataSource.SiteCollectionAppCatalogExists && status.createTestSite) {
+                                                // Load the test site
+                                                DataSource.loadTestSite(item).then(
+                                                    // Exists
+                                                    webInfo => {
+                                                        // See if the version match
+                                                        if (webInfo.versionMatchFl) {
+                                                            // Call the update event
+                                                            onUpdate();
+                                                        } else {
+                                                            // Update the app
+                                                            AppActions.updateApp(item, webInfo.web.ServerRelativeUrl).then(() => {
+                                                                // Call the update event
+                                                                onUpdate();
+                                                            });
+                                                        }
+                                                    },
+
+                                                    // Doesn't exist
+                                                    () => {
+                                                        // Create the test site
+                                                        AppActions.createTestSite(item, onUpdate);
+                                                    }
+                                                );
+                                            } else {
+                                                // Call the update event
+                                                onUpdate();
+                                            }
                                         });
                                     });
 


### PR DESCRIPTION
Adds the createTestSite configuration option for the status. If set to true, it will ensure the test site is created and the latest version of the app is deployed.