### PR TITLE
Updated Security

### DIFF
--- a/src/cfg.ts
+++ b/src/cfg.ts
@@ -955,13 +955,13 @@ export const createSecurityGroups = (): PromiseLike<void> => {
         });
 
         // Get the default owners group
-        web.AssociatedMemberGroup().execute(group => {
+        web.AssociatedOwnerGroup().execute(group => {
             // Set the owners group
             webOwnersGroup = group;
         });
 
         // Get the default visitors group
-        web.AssociatedMemberGroup().execute(group => {
+        web.AssociatedVisitorGroup().execute(group => {
             // Set the visitors group
             webVisitorsGroup = group;
         });


### PR DESCRIPTION
The default owners, members and visitors group of the site will have read access to the Apps and App Assessments. This will be required for the app to work for non-admins/approvers.