### PR TITLE
New User Type "Current User"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The available values for the user type property values.
 | Name | Description |
 | --- | --- |
 | ApproversGroup | A reference to the approver's security group. |
+| CurrentUser | A reference to the current user. |
 | Developers | The developers of the application. _Linked to the AppOwners metadata field._ |
 | DevelopersGroup | A reference to the developer's security group. |
 | Sponsor | The sponsor of the application. _Linked to the AppSponsor metadata field._ |

--- a/src/appNotifications.ts
+++ b/src/appNotifications.ts
@@ -54,7 +54,20 @@ export class AppNotifications {
             if (key == "User.Name") {
                 // Set the value
                 value = ContextInfo.userDisplayName;
-            } else {
+            }
+            // Else, see if it's the current user
+            else if (key.indexOf("CurrentUser") == 0) {
+                // Get the sub-keys and update the value
+                let keys = key.split('.');
+                value = AppSecurity.CurrentUser;
+
+                // Parse the properties of complex fields
+                for (let j = 1; j < keys.length; j++) {
+                    // Set the value
+                    value = value && value[keys[j]] ? value[keys[j]] : null;
+                }
+            }
+            else {
                 // Get the sub-keys and update the value
                 let keys = key.split('.');
                 value = item[keys[0]]
@@ -76,6 +89,12 @@ export class AppNotifications {
             case "AppStatus":
                 // Set the value
                 value = status;
+                break;
+
+            // See if it's the current user
+            case "CurrentUser":
+                // Default to the user name
+                value = AppSecurity.CurrentUser.Title;
                 break;
 
             // Url to the dashboard page

--- a/src/appSecurity.ts
+++ b/src/appSecurity.ts
@@ -63,6 +63,23 @@ export class AppSecurity {
         });
     }
 
+    // Current User
+    private static _currentUser: Types.SP.User = null;
+    static get CurrentUser(): Types.SP.User { return this._currentUser; }
+    static loadCurrentUser(): PromiseLike<void> {
+        // Return a promise
+        return new Promise((resolve, reject) => {
+            // Get the current user
+            Web(Strings.SourceUrl).CurrentUser().execute(user => {
+                // Set the user
+                this._currentUser = user;
+
+                // Resolve the request
+                resolve();
+            }, reject);
+        });
+    }
+
     // Developer Security Group
     private static _devGroup: Types.SP.GroupOData = null;
     static get DevGroup(): Types.SP.GroupOData { return this._devGroup; }
@@ -137,25 +154,23 @@ export class AppSecurity {
     static init(appCatalogUrl: string, tenantAppCatalogUrl: string): PromiseLike<void> {
         // Return a promise
         return new Promise((resolve, reject) => {
-            // Initialize the SC Owner
-            this.initSCOwner(appCatalogUrl).then(() => {
+            // Execute the requests
+            Promise.all([
+                // Initialize the SC Owner
+                this.initSCOwner(appCatalogUrl),
                 // Initialize the tenant owner
-                this.initTenantOwner(tenantAppCatalogUrl).then(() => {
-                    // Load the approver's group
-                    this.loadApproverGroup().then(() => {
-                        // Load the developer's group
-                        this.loadDevGroup().then(() => {
-                            // Load the owner's group
-                            this.loadOwnerGroup().then(() => {
-                                // Load the sponsor's group
-                                this.loadSponsorGroup().then(() => {
-                                    // Resolve the request
-                                    resolve();
-                                }, reject);
-                            }, reject);
-                        }, reject);
-                    }, reject);
-                }, reject);
+                this.initTenantOwner(tenantAppCatalogUrl),
+                // Load the approver's group
+                this.loadApproverGroup(),
+                // Load the developer's group
+                this.loadDevGroup(),
+                // Load the owner's group
+                this.loadOwnerGroup(),
+                // Load the sponsor's group
+                this.loadSponsorGroup()
+            ]).then(() => {
+                // Resolve the request
+                resolve();
             }, reject);
         });
     }

--- a/src/appSecurity.ts
+++ b/src/appSecurity.ts
@@ -156,6 +156,8 @@ export class AppSecurity {
         return new Promise((resolve, reject) => {
             // Execute the requests
             Promise.all([
+                // Load the current user
+                this.loadCurrentUser(),
                 // Initialize the SC Owner
                 this.initSCOwner(appCatalogUrl),
                 // Initialize the tenant owner


### PR DESCRIPTION
Added the CurrentUser "User Type" configuration option. Updated the notification to allow for the current user's sub properties to be set using the "." to separate them. By default it will use the "Title" property if no sub property is set.