### PR TITLE
Issue 139 - Update App Error Logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-catalog-dashboard",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Management of apps in tenant app catalog.",
   "main": "src/index.ts",
   "scripts": {

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "App Catalog Dashboard",
     "id": "fedf9867-a1dc-4204-8a07-f4c2cf162359",
-    "version": "0.0.4.6",
+    "version": "0.0.4.7",
     "includeClientSideAssets": true,
     "isDomainIsolated": false,
     "skipFeatureDeployment": true,

--- a/src/appActions.ts
+++ b/src/appActions.ts
@@ -507,13 +507,24 @@ export class AppActions {
                                                         onUpdate();
                                                     }
                                                 }, () => {
-                                                    // Log the error
-                                                    ErrorDialog.show("Getting Apps", "There was an error getting the available apps from the app catalog.");
-
-                                                    // Error deploying the app
-                                                    // TODO - Show an error
-                                                    // Call the update event
-                                                    onUpdate();
+                                                    // See if this isn't the tenant
+                                                    if (!tenantFl) {
+                                                        // Refresh the apps
+                                                        DataSource.loadSiteCollectionItems().then(() => {
+                                                            // See if the app item exists
+                                                            let appItem = DataSource.getSiteCollectionAppItem(item.AppProductID);
+                                                            if (appItem) {
+                                                                // Log the error
+                                                                ErrorDialog.show("Deploy Error", "The app was added to the catalog successfully, but there was an error with it.");
+                                                            } else {
+                                                                // Log the error
+                                                                ErrorDialog.show("Getting Apps", "There was an error getting the available apps from the app catalog.");
+                                                            }
+                                                        });
+                                                    } else {
+                                                        // Log the error
+                                                        ErrorDialog.show("Getting Apps", "There was an error getting the available apps from the app catalog.");
+                                                    }
                                                 });
                                             });
                                         },

--- a/src/appActions.ts
+++ b/src/appActions.ts
@@ -228,7 +228,7 @@ export class AppActions {
 
         // Deploy the solution
         // Force the skip feature deployment to be false for a test site.
-        this.deploy(item, false, false, () => {
+        this.deploy(item, false, false, onComplete, () => {
             // Update the loading dialog
             LoadingDialog.setHeader("Creating the Test Site");
             LoadingDialog.setBody("Creating the sub-web for testing the application.");
@@ -388,7 +388,7 @@ export class AppActions {
     }
 
     // Deploys the solution to the app catalog
-    static deploy(item: IAppItem, tenantFl: boolean, skipFeatureDeployment: boolean, onUpdate: () => void) {
+    static deploy(item: IAppItem, tenantFl: boolean, skipFeatureDeployment: boolean, onError: () => void, onUpdate: () => void) {
         let appFile: Types.SP.File = null;
 
         // Log
@@ -498,6 +498,9 @@ export class AppActions {
                                                         }, () => {
                                                             // Log the error
                                                             ErrorDialog.show("Updating App", "There was an error setting the tenant deployed flag.");
+
+                                                            // Call the event
+                                                            onError();
                                                         });
                                                     } else {
                                                         // Hide the dialog
@@ -512,7 +515,7 @@ export class AppActions {
                                                         // Refresh the apps
                                                         DataSource.loadSiteCollectionItems().then(() => {
                                                             // See if the app item exists
-                                                            let appItem = DataSource.getSiteCollectionAppItem(item.AppProductID);
+                                                            let appItem = DataSource.getSiteCollectionAppItem(appFile.Name);
                                                             if (appItem) {
                                                                 // Log the error
                                                                 ErrorDialog.show("Deploy Error", "The app was added to the catalog successfully, but there was an error with it.");
@@ -520,10 +523,16 @@ export class AppActions {
                                                                 // Log the error
                                                                 ErrorDialog.show("Getting Apps", "There was an error getting the available apps from the app catalog.");
                                                             }
+
+                                                            // Call the event
+                                                            onError();
                                                         });
                                                     } else {
                                                         // Log the error
                                                         ErrorDialog.show("Getting Apps", "There was an error getting the available apps from the app catalog.");
+
+                                                        // Call the event
+                                                        onError();
                                                     }
                                                 });
                                             });
@@ -531,12 +540,18 @@ export class AppActions {
                                         ex => {
                                             // Log the error
                                             ErrorDialog.show("Loading App", "There was an error loading the app item.", ex);
+
+                                            // Call the event
+                                            onError();
                                         }
                                     );
                                 },
                                 ex => {
                                     // Log the error
                                     ErrorDialog.show("Adding App", "There was an error adding the app to the app catalog.", ex);
+
+                                    // Call the event
+                                    onError();
                                 }
                             );
                         });
@@ -544,12 +559,18 @@ export class AppActions {
                     ex => {
                         // Log the error
                         ErrorDialog.show("Getting Context", "There was an error getting the web context", ex);
+
+                        // Call the event
+                        onError();
                     }
                 );
             },
             ex => {
                 // Log the error
                 ErrorDialog.show("Reading File", "There was an error reading the app package file.", ex);
+
+                // Call the event
+                onError();
             }
         );
     }
@@ -952,7 +973,7 @@ export class AppActions {
     }
 
     // Updates the app
-    static updateApp(item: IAppItem, siteUrl: string, isTestSite: boolean): PromiseLike<void> {
+    static updateApp(item: IAppItem, siteUrl: string, isTestSite: boolean, onError: () => void): PromiseLike<void> {
         // Return a promise
         return new Promise((resolve) => {
             // Log
@@ -981,7 +1002,7 @@ export class AppActions {
                             ErrorDialog.logInfo(`Upgrading the app '${item.Title}' with id ${item.AppProductID}...`);
 
                             // Deploy the solution
-                            this.deploy(item, false, isTestSite ? false : item.AppSkipFeatureDeployment, () => {
+                            this.deploy(item, false, isTestSite ? false : item.AppSkipFeatureDeployment, onError, () => {
                                 // Update the dialog
                                 LoadingDialog.setHeader("Upgrading the Solution");
 

--- a/src/appDashboard.ts
+++ b/src/appDashboard.ts
@@ -208,6 +208,7 @@ export class AppDashboard {
 
         // See if the app is deployed and has an error message
         let errorMessage = DataSource.DocSetSCApp ? DataSource.DocSetSCApp.ErrorMessage : null;
+        errorMessage = DataSource.DocSetSCAppCatalogItem ? DataSource.DocSetSCAppCatalogItem.AppPackageErrorMessage : errorMessage;
         errorMessage = DataSource.DocSetSCAppItem ? DataSource.DocSetSCAppItem.AppPackageErrorMessage : errorMessage;
         if (errorMessage && errorMessage != "No errors.") {
             // Show the element

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -74,7 +74,7 @@ export class AppForms {
                                                                 onUpdate();
                                                             } else {
                                                                 // Update the app
-                                                                AppActions.updateApp(item, webInfo.web.ServerRelativeUrl, true).then(() => {
+                                                                AppActions.updateApp(item, webInfo.web.ServerRelativeUrl, true, onUpdate).then(() => {
                                                                     // Call the update event
                                                                     onUpdate();
                                                                 });
@@ -313,7 +313,7 @@ export class AppForms {
                 let skipFeatureDeployment = form ? form.getValues()["SkipFeatureDeployment"] : false;
 
                 // Deploy the app
-                AppActions.deploy(item, tenantFl, skipFeatureDeployment, () => {
+                AppActions.deploy(item, tenantFl, skipFeatureDeployment, onUpdate, () => {
                     // Call the update event
                     onUpdate();
                 });
@@ -1693,7 +1693,7 @@ ${ContextInfo.userDisplayName}`.trim());
                 Modal.hide();
 
                 // Update the app
-                AppActions.updateApp(item, siteUrl, true).then(() => {
+                AppActions.updateApp(item, siteUrl, true, onUpdate).then(() => {
                     // Call the update event
                     onUpdate();
                 });
@@ -1803,7 +1803,7 @@ ${ContextInfo.userDisplayName}`.trim());
                             // Return a promise
                             return new Promise(resolve => {
                                 // Upgrade the app
-                                AppActions.updateApp(appItem, item.data, false).then(() => {
+                                AppActions.updateApp(appItem, item.data, false, () => { resolve(null); }).then(() => {
                                     // Update the loading dialog
                                     LoadingDialog.setHeader("Upgrading Apps");
                                     LoadingDialog.setBody("Upgrading " + (++counter) + " of " + items.length);

--- a/src/btnActions.ts
+++ b/src/btnActions.ts
@@ -556,26 +556,29 @@ export class ButtonActions {
 
                         // Test site doesn't exist
                         () => {
-                            // Render the create button
-                            tooltips.add({
-                                content: "Creates the test site for the app.",
-                                btnProps: {
-                                    text: "Create Test Site",
-                                    iconClassName: "me-1",
-                                    iconSize: 20,
-                                    iconType: chatSquareDots,
-                                    isDisabled: !AppSecurity.IsSiteAppCatalogOwner,
-                                    isSmall: true,
-                                    type: Components.ButtonTypes.OutlinePrimary,
-                                    onClick: () => {
-                                        // Display the create test site form
-                                        this._forms.createTestSite(this._item, () => {
-                                            // Call the update event
-                                            this._onUpdate();
-                                        });
+                            // Ensure the app item exists
+                            if (DataSource.DocSetSCAppCatalogItem) {
+                                // Render the create button
+                                tooltips.add({
+                                    content: "Creates the test site for the app.",
+                                    btnProps: {
+                                        text: "Create Test Site",
+                                        iconClassName: "me-1",
+                                        iconSize: 20,
+                                        iconType: chatSquareDots,
+                                        isDisabled: !AppSecurity.IsSiteAppCatalogOwner || !DataSource.DocSetSCAppCatalogItem.IsValidAppPackage,
+                                        isSmall: true,
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            // Display the create test site form
+                                            this._forms.createTestSite(this._item, () => {
+                                                // Call the update event
+                                                this._onUpdate();
+                                            });
+                                        }
                                     }
-                                }
-                            });
+                                });
+                            }
                         }
                     );
                     break;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -49,6 +49,6 @@ const Strings = {
     ProjectDescription: "App Dashboard for Developers",
     SolutionUrl: AssetsUrl + "index.html",
     SourceUrl: ContextInfo.webServerRelativeUrl,
-    Version: "0.0.4.6",
+    Version: "0.0.4.7",
 };
 export default Strings;


### PR DESCRIPTION
When deploying an app that is invalid, the solution would spin and "get stuck". This is due to the "AvailableApps" method not returning apps in error. We have to get the list items and compare using the app's file name, since very little metadata is populated for apps in error.