### PR TITLE
App Sponsor Not Added to Group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-catalog-dashboard",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Management of apps in tenant app catalog.",
   "main": "src/index.ts",
   "scripts": {

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "App Catalog Dashboard",
     "id": "fedf9867-a1dc-4204-8a07-f4c2cf162359",
-    "version": "0.0.4.7",
+    "version": "0.0.4.8",
     "includeClientSideAssets": true,
     "isDomainIsolated": false,
     "skipFeatureDeployment": true,

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -766,9 +766,40 @@ ${ContextInfo.userDisplayName}`.trim());
                 // Return the properties
                 return props;
             },
-            onUpdate: () => {
-                // Call the update event
-                onUpdate();
+            onUpdate: (item: IAppItem) => {
+                // See if this is a new item
+                if (item.AppStatus == "New") {
+                    // Log
+                    ErrorDialog.logInfo(`Validating the app sponsor id: '${item.AppSponsorId}'`);
+
+                    // Get the sponsor
+                    let sponsor = AppSecurity.getSponsor(item.AppSponsorId);
+                    if (sponsor == null && item.AppSponsorId > 0) {
+                        // Log
+                        ErrorDialog.logInfo(`App sponsor not in group. Adding the user...`);
+
+                        // Add the sponsor to the group
+                        AppSecurity.addSponsor(item.AppSponsorId).then(() => {
+                            // Get the status
+                            let status = AppConfig.Status[item.AppStatus];
+
+                            // Send the notifications
+                            AppNotifications.sendEmail(status.notification, item, false).then(() => {
+                                // Call the update event
+                                onUpdate();
+
+                                // Hide the dialog
+                                LoadingDialog.hide();
+                            });
+                        });
+                    } else {
+                        // Call the update event
+                        onUpdate();
+                    }
+                } else {
+                    // Call the update event
+                    onUpdate();
+                }
             }
         });
     }
@@ -1652,9 +1683,15 @@ ${ContextInfo.userDisplayName}`.trim());
                                         });
                                     }
 
+                                    // Log
+                                    ErrorDialog.logInfo(`Validating the app sponsor id: '${item.AppSponsorId}'`);
+
                                     // Get the sponsor
                                     let sponsor = AppSecurity.getSponsor(item.AppSponsorId);
                                     if (sponsor == null && item.AppSponsorId > 0) {
+                                        // Log
+                                        ErrorDialog.logInfo(`App sponsor not in group. Adding the user...`);
+
                                         // Add the sponsor to the group
                                         AppSecurity.addSponsor(item.AppSponsorId).then(() => {
                                             // Complete the request

--- a/src/appSecurity.ts
+++ b/src/appSecurity.ts
@@ -276,6 +276,9 @@ export class AppSecurity {
     }
     // Add the user to the sponsor group
     static addSponsor(userId: number): PromiseLike<void> {
+        // Log
+        ErrorDialog.logInfo(`Adding the user with id '${userId}' to the App Sponsor site group...`);
+
         // Return a promise
         return new Promise((resolve, reject) => {
             // Add the user
@@ -285,7 +288,16 @@ export class AppSecurity {
 
                 // Resolve the request
                 resolve();
-            }, reject);
+            },
+                // Error
+                ex => {
+                    // Log
+                    ErrorDialog.logError(`Error adding the app sponsor not added to the group.`);
+                    ErrorDialog.logError(`Error Message: ${ex.response}`)
+
+                    // Reject the request
+                    reject();
+                });
         });
     }
     static getSponsor(userId: number): Types.SP.User {

--- a/src/cfg.ts
+++ b/src/cfg.ts
@@ -1122,11 +1122,11 @@ export const createSecurityGroups = (): PromiseLike<void> => {
             let updateOwners = () => {
                 // Return a promise
                 return new Promise((resolve, reject) => {
-                    // Execute against the groups
-                    Helper.Executor([devGroup], group => {
-                        // Set the site owner
-                        return Helper.setGroupOwner(group.Title, approveGroup.Title, Strings.SourceUrl);
-                    }).then(resolve, reject);
+                    // Set the dev group owner
+                    Helper.setGroupOwner(devGroup.Title, approveGroup.Title, Strings.SourceUrl).then(() => {
+                        // Set the sponsor group owner
+                        Helper.setGroupOwner(sponsorGroup.Title, devGroup.Title, Strings.SourceUrl).then(resolve, reject);
+                    }, reject);
                 });
             }
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -49,6 +49,6 @@ const Strings = {
     ProjectDescription: "App Dashboard for Developers",
     SolutionUrl: AssetsUrl + "index.html",
     SourceUrl: ContextInfo.webServerRelativeUrl,
-    Version: "0.0.4.7",
+    Version: "0.0.4.8",
 };
 export default Strings;


### PR DESCRIPTION
The app sponsor wasn't being added to the group. The group owner needs to be the developer's group, since this is the group that is allowed to add packages to the solution and sets the sponsor group.

The edit form was updated to check for "new" items and add the sponsor if it wasn't added during the upload of a new package.