### PR TITLE
Implemented Extraction of Client Side Assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-catalog-dashboard",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Management of apps in tenant app catalog.",
   "main": "src/index.ts",
   "scripts": {

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "App Catalog Dashboard",
     "id": "fedf9867-a1dc-4204-8a07-f4c2cf162359",
-    "version": "0.0.5.3",
+    "version": "0.0.5.4",
     "includeClientSideAssets": true,
     "isDomainIsolated": false,
     "skipFeatureDeployment": true,

--- a/src/appActions.ts
+++ b/src/appActions.ts
@@ -220,7 +220,7 @@ export class AppActions {
     }
 
     // Creates the archive folder
-    private static createClientSideAssetsFolder(rootFolder: Types.SP.IFolder): PromiseLike<Types.SP.Folder> {
+    static createClientSideAssetsFolder(rootFolder: Types.SP.IFolder): PromiseLike<Types.SP.Folder> {
         // Log
         ErrorDialog.logInfo("Getting the client side assets folder...");
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -51,6 +51,6 @@ const Strings = {
     ProjectDescription: "App Dashboard for Developers",
     SolutionUrl: AssetsUrl + "index.html",
     SourceUrl: ContextInfo.webServerRelativeUrl,
-    Version: "0.0.5.3",
+    Version: "0.0.5.4",
 };
 export default Strings;


### PR DESCRIPTION
Updated the adding of a new app and upgrading of an existing app to:

1. Ensure a clientsideassets folder exists in the app's docset folder
2. Clear the folder (for upgrade only)
3. Adds the client side asset files extracted from the app package