### PR TITLE
New Action Button - Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The available values for the `actions` status property.
 | EditTechReview | Displays the edit form to modify the technical review assessment. |
 | EditTestCases | Displays the edit form to modify the test cases assessment. |
 | GetHelp | Displays a `help` button to send a notification to the app developers and app sponsor. |
+| Metadata| Displays a button to update the metadata of an approved app. This will revert the item to "Pending Approval". |
 | Notification | Displays a button to notify user types. |
 | Submit | Displays the submission form to request approval. |
 | TestSite | Displays a `create` or `view` button to the test site collection. |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The tool will track a history of actions taken on an app. This audit log is visi
 | App Approved | Logged when an app is approved. |
 | App Catalog Request | Logged when an app catalog is being requested for a site collection. |
 | App Deployed | Logged when an app is deployed to a site collection app catalog. |
+| App Metadata Updated | Logged when the metadata is updated past the technical review state. |
 | App Rejected | Logged when an app is rejected. |
 | App Retracted | Logged when an app is retracted. |
 | App Resubmitted | Logged when an app is resubmitted from a rejected state. |

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -2160,7 +2160,14 @@ export class AppForms {
 
     // Updates the metadata of the app
     updateMetadata(item: IAppItem, onUpdate: () => void) {
-        // TODO
+        // Display the edit form
+        this.edit(item.Id, () => {
+            // See if we are past the test case status
+            if (AppConfig.Status[item.AppStatus].stepNumber < AppConfig.Status[AppConfig.TechReviewStatus].stepNumber) {
+                // Update the status
+                item.update({ AppStatus: AppConfig.TechReviewStatus }).execute(onUpdate);
+            }
+        });
     }
 
     // Displays the ugprade from

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -1,4 +1,4 @@
-import { LoadingDialog, Modal } from "dattatable";
+import { AuditLog, LoadingDialog, Modal } from "dattatable";
 import { Components, ContextInfo, Helper, List, SPTypes, Web } from "gd-sprest-bs";
 import { AppActions } from "./appActions";
 import { AppConfig, IStatus } from "./appCfg";
@@ -2163,7 +2163,16 @@ export class AppForms {
         // Display the edit form
         this.edit(item.Id, () => {
             // See if we are past the test case status
-            if (AppConfig.Status[item.AppStatus].stepNumber < AppConfig.Status[AppConfig.TechReviewStatus].stepNumber) {
+            if (AppConfig.Status[item.AppStatus].stepNumber > AppConfig.Status[AppConfig.TechReviewStatus].stepNumber) {
+                // Log
+                DataSource.logItem({
+                    LogUserId: ContextInfo.userId,
+                    ParentId: item.AppProductID,
+                    ParentListName: Strings.Lists.Apps,
+                    Title: DataSource.AuditLogStates.AppMetadataUpdated,
+                    LogComment: `The app's metadata was updated. Reverting the state for a technical review.`
+                }, item);
+
                 // Update the status
                 item.update({ AppStatus: AppConfig.TechReviewStatus }).execute(onUpdate);
             }

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -2158,6 +2158,11 @@ export class AppForms {
         Modal.show();
     }
 
+    // Updates the metadata of the app
+    updateMetadata(item: IAppItem, onUpdate: () => void) {
+        // TODO
+    }
+
     // Displays the ugprade from
     upgrade(appItem: IAppItem) {
         // Clear the modal

--- a/src/btnActions.ts
+++ b/src/btnActions.ts
@@ -602,6 +602,29 @@ ${ContextInfo.userDisplayName}`.trim()
           });
           break;
 
+        // Metadata
+        case "Metadata":
+          // Render the button
+          tooltips.add({
+            content: "Displays the metadata and reverts the item to a 'Pending Approval' state if an update is made.",
+            btnProps: {
+              text: "Update Metadata",
+              iconClassName: "me-1",
+              iconSize: 20,
+              iconType: windowStack,
+              isSmall: true,
+              type: Components.ButtonTypes.OutlinePrimary,
+              onClick: () => {
+                // Display the send notification form
+                this._forms.updateMetadata(DataSource.AppItem, () => {
+                  // Call the update event
+                  this._onUpdate();
+                });
+              },
+            },
+          });
+          break;
+
         // Notification
         case "Notification":
           // Render the button

--- a/src/btnActions.ts
+++ b/src/btnActions.ts
@@ -604,25 +604,28 @@ ${ContextInfo.userDisplayName}`.trim()
 
         // Metadata
         case "Metadata":
-          // Render the button
-          tooltips.add({
-            content: "Displays the metadata and reverts the item to a 'Pending Approval' state if an update is made.",
-            btnProps: {
-              text: "Update Metadata",
-              iconClassName: "me-1",
-              iconSize: 20,
-              iconType: windowStack,
-              isSmall: true,
-              type: Components.ButtonTypes.OutlinePrimary,
-              onClick: () => {
-                // Display the send notification form
-                this._forms.updateMetadata(DataSource.AppItem, () => {
-                  // Call the update event
-                  this._onUpdate();
-                });
+          // Ensure the user can edit
+          if (canEdit) {
+            // Render the button
+            tooltips.add({
+              content: "Displays the metadata and reverts the item to a 'Pending Approval' state if an update is made.",
+              btnProps: {
+                text: "Update Metadata",
+                iconClassName: "me-1",
+                iconSize: 20,
+                iconType: windowStack,
+                isSmall: true,
+                type: Components.ButtonTypes.OutlinePrimary,
+                onClick: () => {
+                  // Display the send notification form
+                  this._forms.updateMetadata(DataSource.AppItem, () => {
+                    // Call the update event
+                    this._onUpdate();
+                  });
+                },
               },
-            },
-          });
+            });
+          }
           break;
 
         // Notification

--- a/src/ds.ts
+++ b/src/ds.ts
@@ -675,6 +675,7 @@ export class DataSource {
         AppApproved: "App Approved",
         AppCatalogRequest: "App Catalog Request",
         AppDeployed: "App Deployed",
+        AppMetadataUpdated: "App Metadata Updated",
         AppRejected: "App Rejected",
         AppRetracted: "App Retracted",
         AppResubmitted: "App Resubmitted",
@@ -684,7 +685,7 @@ export class DataSource {
         AppUpgraded: "App Upgraded",
         CreateTestSite: "Create Test Site",
         DeleteApp: "Delete App",
-        DeleteTestSite: "Delete Test Site"
+        DeleteTestSite: "Delete Test Site",
     }
 
     // Audit Log


### PR DESCRIPTION
Added a new action button for updating the metadata. This will revert the status back to a technical review if it's currently past it. The audit log has been updated to include this new update type.