### PR TITLE
Remove EMail From Main Query

### DIFF
--- a/src/ds.ts
+++ b/src/ds.ts
@@ -210,7 +210,6 @@ export class DataSource {
                         "AppDevelopers/EMail",
                         "AppDevelopers/Title",
                         "AppSponsor/Id",
-                        "AppSponsor/EMail",
                         "AppSponsor/Title",
                         "CheckoutUser/Id",
                         "CheckoutUser/Title",

--- a/src/ds.ts
+++ b/src/ds.ts
@@ -207,7 +207,6 @@ export class DataSource {
                         "FileLeafRef",
                         "ContentTypeId",
                         "AppDevelopers/Id",
-                        "AppDevelopers/EMail",
                         "AppDevelopers/Title",
                         "AppSponsor/Id",
                         "AppSponsor/Title",

--- a/src/ds.ts
+++ b/src/ds.ts
@@ -213,7 +213,6 @@ export class DataSource {
                         "AppSponsor/EMail",
                         "AppSponsor/Title",
                         "CheckoutUser/Id",
-                        "CheckoutUser/EMail",
                         "CheckoutUser/Title",
                     ],
                 },
@@ -484,7 +483,7 @@ export class DataSource {
                             "*", "Id", "FileLeafRef", "ContentTypeId",
                             "AppDevelopers/Id", "AppDevelopers/EMail", "AppDevelopers/Title",
                             "AppSponsor/Id", "AppSponsor/EMail", "AppSponsor/Title",
-                            "CheckoutUser/Id", "CheckoutUser/EMail", "CheckoutUser/Title"
+                            "CheckoutUser/Id", "CheckoutUser/Title"
                         ]
                     }
                 }).then(info => {


### PR DESCRIPTION
I reviewed the main query to see what is using the EMail property for App Developers, App Sponsor and the Checked Out User fields. Only the id or title property is used by the main query, while the App Details will use the EMail property.

The query for the app details contains the EMail, but I removed the EMail from the main query.