### PR TITLE
Tenant Upgrade Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The available values for the `actions` status property.
 | Submit | Displays the submission form to request approval. |
 | TestSite | Displays a `create` or `view` button to the test site collection. |
 | Upgrade | Displays an upgrade button if site collection url(s) exist. |
+| UpgradeTenant | Displays an upgrade button if tenant version needs to be upgraded. |
 | View | Displays the app metadata view form. |
 | ViewSourceControl | Displays the app's source control in a new tab. |
 | ViewTechReview | Displays the last technical review for the application. |

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -138,7 +138,7 @@ export class AppForms {
                                                             onUpdate();
                                                         } else {
                                                             // Update the app
-                                                            AppActions.updateApp(web.ServerRelativeUrl, true, onUpdate).then(() => {
+                                                            AppActions.updateSiteApp(web.ServerRelativeUrl, true, onUpdate).then(() => {
                                                                 // Call the update event
                                                                 onUpdate();
                                                             });
@@ -2194,7 +2194,7 @@ export class AppForms {
                 Modal.hide();
 
                 // Update the app
-                AppActions.updateApp(siteUrl, true, onUpdate).then(() => {
+                AppActions.updateSiteApp(siteUrl, true, onUpdate).then(() => {
                     // Send the notifications
                     AppNotifications.sendAppTestSiteUpgradedEmail(DataSource.AppItem).then(() => {
                         // Call the update event
@@ -2208,6 +2208,46 @@ export class AppForms {
                         ParentListName: Strings.Lists.Apps,
                         Title: DataSource.AuditLogStates.AppUpdated,
                         LogComment: `The app ${item.Title} was updated for site: ${siteUrl}`
+                    }, item);
+                });
+            }
+        }).el);
+
+        // Show the modal
+        Modal.show();
+    }
+
+    // Updates the tenant app
+    updateTenantApp(item: IAppItem, onUpdate: () => void) {
+        // Set the header
+        Modal.setHeader("Update Tenant App");
+
+        // Set the body
+        Modal.setBody("Are you sure you want to update the app?");
+
+        // Render the footer
+        Modal.setFooter(Components.Button({
+            text: "Update",
+            type: Components.ButtonTypes.OutlineSuccess,
+            onClick: () => {
+                // Close the modal
+                Modal.hide();
+
+                // Update the app
+                AppActions.updateTenantApp(DataSource.AppCatalogTenantItem ? DataSource.AppCatalogTenantItem.SkipDeploymentFeature : false, onUpdate).then(() => {
+                    // Send the notifications
+                    AppNotifications.sendAppUpgradedEmail(DataSource.AppItem).then(() => {
+                        // Call the update event
+                        onUpdate();
+                    });
+
+                    // Log
+                    DataSource.logItem({
+                        LogUserId: ContextInfo.userId,
+                        ParentId: item.AppProductID,
+                        ParentListName: Strings.Lists.Apps,
+                        Title: DataSource.AuditLogStates.AppUpdated,
+                        LogComment: `The tenant app ${item.Title} was updated.`
                     }, item);
                 });
             }
@@ -2337,7 +2377,7 @@ export class AppForms {
                             // Return a promise
                             return new Promise(resolve => {
                                 // Upgrade the app
-                                AppActions.updateApp(item.data, false, () => { resolve(null); }).then(() => {
+                                AppActions.updateSiteApp(item.data, false, () => { resolve(null); }).then(() => {
                                     // Update the loading dialog
                                     LoadingDialog.setHeader("Upgrading Apps");
                                     LoadingDialog.setBody("Upgrading " + (++counter) + " of " + items.length);

--- a/src/appForms.ts
+++ b/src/appForms.ts
@@ -2225,6 +2225,16 @@ export class AppForms {
         // Set the body
         Modal.setBody("Are you sure you want to update the app?");
 
+        let form = Components.Form({
+            el: Modal.BodyElement,
+            controls: [{
+                name: "SkipFeatureDeployment",
+                title: "Skip Feature Deployment",
+                type: Components.FormControlTypes.Switch,
+                value: DataSource.AppCatalogTenantItem ? DataSource.AppCatalogTenantItem.SkipDeploymentFeature : false
+            }]
+        });
+
         // Render the footer
         Modal.setFooter(Components.Button({
             text: "Update",
@@ -2234,7 +2244,8 @@ export class AppForms {
                 Modal.hide();
 
                 // Update the app
-                AppActions.updateTenantApp(DataSource.AppCatalogTenantItem ? DataSource.AppCatalogTenantItem.SkipDeploymentFeature : false, onUpdate).then(() => {
+                let skipFeatureDeployment = form.getValues()["SkipFeatureDeployment"];
+                AppActions.updateTenantApp(skipFeatureDeployment, onUpdate).then(() => {
                     // Send the notifications
                     AppNotifications.sendAppUpgradedEmail(DataSource.AppItem).then(() => {
                         // Call the update event

--- a/src/btnActions.ts
+++ b/src/btnActions.ts
@@ -832,6 +832,43 @@ ${ContextInfo.userDisplayName}`.trim()
           }
           break;
 
+        // Upgrade Tenant
+        case "UpgradeTenant":
+          // See if the current version is not deployed
+          let tenantApp = DataSource.getTenantAppItem(DataSource.AppItem.AppProductID);
+          if (
+            DataSource.AppItem.AppVersion !=
+            tenantApp.InstalledVersion &&
+            DataSource.AppItem.AppVersion !=
+            tenantApp.AppCatalogVersion
+          ) {
+            // Render the update button
+            tooltips.add({
+              content:
+                "Versions do not match. Click to update the test site.",
+              btnProps: {
+                text: "Update Test Site",
+                iconClassName: "me-1",
+                iconSize: 20,
+                iconType: appIndicator,
+                isDisabled: !AppSecurity.IsSiteAppCatalogOwner,
+                isSmall: true,
+                type: Components.ButtonTypes.OutlinePrimary,
+                onClick: () => {
+                  // Show the update form
+                  this._forms.updateTenantApp(
+                    DataSource.AppItem,
+                    () => {
+                      // Call the update event
+                      this._onUpdate();
+                    }
+                  );
+                },
+              },
+            });
+          }
+          break;
+
         // View
         case "View":
           // Render the button


### PR DESCRIPTION
Renamed the existing updateApp to updateSiteApp. Copied the updateApp method to updateTenantApp. Updated the references to the common methods to point towards a tenant deployment. Updated the new form to include the skip deployment flag.